### PR TITLE
Module 3 destructuring spread

### DIFF
--- a/sprint_3/3_4_intro_react_2.md
+++ b/sprint_3/3_4_intro_react_2.md
@@ -220,36 +220,14 @@ export default Greetings;
 
 > Estos componentes _dummies_ también se llaman componentes funcionales (_functional components_) o, más específicamente, componentes funcionales sin estado (_stateless functional components_), porque tienen forma de función y carecen de estado.
 
-Aunque parezca difícil, esta sintaxis se puede simplificar aún más. Recordamos que en ES2015 tenemos la habilidad de _destructuring_ de objetos. `props` es un objeto que podemos dividir en variables con los nombres de las `props`, directamente:
+Si lo combinamos con el _return_ implícito de las _arrow functions_ queda así:
 
 ```js
-// ...
-const Greetings = props => {
-  const { name } = props; // "destructuring" de objeto
-  return <h1>Hello, {name}!</h1>;
-};
-// ...
-```
+import React from 'react';
+// "arrow function" sin llaves, con "return" implícito
+const Greetings = props => <h1>Hello, {props.name}!</h1>;
 
-Podemos hacer _destructuring_ directamente en los parámetros de una función:
-
-```js
-// ...
-const Greetings = ({ name }) => {
-  // "destructuring" en los parámetros
-  return <h1>Hello, {name}!</h1>;
-};
-// ...
-```
-
-Y si lo combinamos con el _return_ implícito de las _arrow functions_, queda así:
-
-```js
-// ...
-const Greetings = (
-  { name } // "arrow function" sin llaves, con "return" implícito
-) => <h1>Hello, {name}!</h1>;
-// ...
+export default Greetings;
 ```
 
 Hemos reducido la declaración de un componente de siete líneas a tres. Es una práctica común hacerlo al revés: declarar un componente nuevo primero como función, _dummy_, y si más tarde necesita estado o comportamiento, [ampliar su declaración](https://reactjs.org/docs/state-and-lifecycle.html#converting-a-function-to-a-class) a la de un componente de clase completo.

--- a/sprint_3/3_6_eventos_react.md
+++ b/sprint_3/3_6_eventos_react.md
@@ -16,7 +16,8 @@
 - [EJERCICIO 5](#ejercicio-5)
 - [EJERCICIO 6](#ejercicio-6)
 - [EJERCICIO 7](#ejercicio-7)
-  <!-- /TOC -->
+
+<!-- /TOC -->
 
 ## Introducción
 
@@ -295,7 +296,7 @@ class MurrayList extends React.Component {
   }
 
   render() {
-    const { handleClick } = this;
+    const handleClick = this.handleClick;
 
     return (
       <section className="section-murrays">
@@ -324,7 +325,8 @@ import React from 'react';
 
 class ReloadButton extends React.Component {
   render() {
-    const { label = 'More', actionToPerform } = this.props;
+    const actionToPerform = this.props.actionToPerform;
+    const label = this.props.label || 'More';
 
     return (
       // Registramos el escuchador que recibimos por props. ¡Lifting hecho!

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -27,7 +27,7 @@ El **estado** de una interfaz son sencillamente los datos que necesitamos para r
 
 ![New GMail cover](assets/images/3_8_new-gmail-web-cover.jpg)
 
-React es especialmente bueno manejando los pequeños cambios que se necesitan en cada uno de los componentes de una web. Cada instancia de un componente tiene un **estado** que refleja cada uno de esos pequeños cambios. React encapsula toda la complejidad y la distribuye en este sistema predecible. Saber utilizar los estados nos permitirá definir cómo se comportarán los componentes en cada momento y declarar _react-ciones_ más elaboradas a según qué interación con el usuario.
+React es especialmente bueno manejando los pequeños cambios que se necesitan en cada uno de los componentes de una web. Cada instancia de un componente tiene un **estado** que refleja cada uno de esos pequeños cambios. React encapsula toda la complejidad y la distribuye en este sistema predecible. Saber utilizar los estados nos permitirá definir cómo se comportarán los componentes en cada momento y declarar _react-ciones_ más elaboradas a según qué interacción con el usuario.
 
 ## Manejo del estado en un componente de React
 

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -278,9 +278,9 @@ console.log(twinSister); // { name: 'Juliette', lastName: 'Smith', age: 39 }
 
 ### Copia vs referencia
 
-Recordemos que en el módulo de javascript aprendimos que si teniamos un array o un objeto literal en una variable, al guardarlo en otra, en realidad guardabamos una _referencia_ del array/objeto.
+Recordemos que en el módulo de javascript aprendimos que si teniamos un array o un objeto literal en una variable, al guardarlo en otra, en realidad guardábamos una _referencia_ del array/objeto.
 
-De manera que si modificábamos o mutábamos una de las dos variables, por ejemplo con un `.push` para el caso del array o cambiando el valor de una propiedad para el caso del objeto, estos cambios también sucedian en la otra variable, ya que el array u objeto contenido en ambas era el mismo.
+De manera que si modificábamos o mutábamos una de las dos variables, por ejemplo con un `.push` para el caso del array o cambiando el valor de una propiedad para el caso del objeto, estos cambios también sucedían en la otra variable, ya que el array u objeto contenido en ambas era el mismo.
 
 El operador _spread_ nos permite hacer una copia de un objeto o array en un momento dado. De manera que si cambiamos o mutamos, por ejemplo, el original, la copia no se ve afectada, ya que son independientes y no comparten referencia.
 

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -314,23 +314,22 @@ this.setState(prevState => {
 });
 ```
 
-Este objeto debía tener como mínimo una de las claves que se encuentran en el primer nivel del estado (`selectedTab, theme, userData`) y React se encarga de que las claves no presentes no se vean afectadas.
+Este objeto debía tener, como mínimo, una de las propiedades que se encuentran en el primer nivel del estado (`selectedTab, theme, userData`) y React se encarga de que las propiedades hermanas no presentes no se vean afectadas.
 
-Pero, y si queremos actualizar una clave que no está a primer nivel, por ejemplo `age`. En estos casos tenemos que identificar la clave madre. En nuestro ejemplo sería `userData` y es la que tenemos que modificar.
+Pero, ¿y si queremos actualizar una propiedad que no está a primer nivel, por ejemplo `age`?. En estos casos tenemos que identificar la propiedad madre en el primer nivel, en nuestro ejemplo sería `userData`, y es la que tenemos que modificar.
 
-Las claves hijas de `userData` (`eyeColor, mostHatedFruit...`) ya no se encuentran a primer nivel y React no las controla, es nuestra responsabilidad que al modificar una las otras no se vean afectadas.
+Las propiedades hijas de `userData` (`eyeColor, mostHatedFruit...`) ya no se encuentran a primer nivel y React no las controla, es nuestra responsabilidad que al modificar una las otras no se vean afectadas.
 
-En este punto, si tenéis que modificar la clave `age`, es posible que penseis en algo así:
+En este punto, si tenéis que modificar la clave `age`, es posible que penséis en algo así:
 
 ```js
 this.setState(prevState => {
-  const newUserData = prevState.userData;
-  newUserData.age = 33;
-  return { userData: newUserData };
+  prevState.userData.age = 33;
+  return { userData: prevState.userData };
 });
 ```
 
-Pero a React **NO le gusta que mutemos arrays y objetos anidados, mejor si creamos una copia**, operador `spread` al rescate:
+Pero a React **NO le gusta que mutemos arrays y objetos anidados, mejor si creamos una copia**, ¡operador `spread` al rescate!:
 
 ```js
 this.setState(prevState => {
@@ -368,7 +367,14 @@ Vamos a crear un formulario donde vamos a poder modificar estos campos del estad
 > NOTA: Cuidado al modificar los campos anidados dentro del objeto `birdthDate`; recuerda que para modificarlos es muy útil usar en el `setState` el operador spread `...` para mantener el resto de datos de ese objeto. Por ejemplo:
 
 ```js
-this.setState((prevState, props) => ({ ...prevState.birthDate, day: 8 }));
+this.setState(prevState => {
+  return {
+    birthDate: {
+      ...prevState.birthDate,
+      day: 8
+    }
+  };
+});
 ```
 
 ### BONUS

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -342,6 +342,8 @@ this.setState(prevState => {
 });
 ```
 
+En este ejemplo creamos una copia del objeto `userData` usando spread y después actualizamos la propiedad age al nuevo valor (33). Ten en cuenta que el orden es importante, y si hay una propiedad repetida, prevalece la de más abajo (como en la cascada de CSS).
+
 ---
 
 #### EJERCICIO 6

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -342,7 +342,7 @@ this.setState(prevState => {
 });
 ```
 
-En este ejemplo creamos una copia del objeto `userData` usando spread y después actualizamos la propiedad age al nuevo valor (33). Ten en cuenta que el orden es importante, y si hay una propiedad repetida, prevalece la de más abajo (como en la cascada de CSS).
+En este ejemplo creamos una copia del objeto `userData` usando spread y después actualizamos la propiedad `age` al nuevo valor (33). Ten en cuenta que el orden es importante, y si hay una propiedad repetida, prevalece la de más abajo (como en la cascada de CSS).
 
 ---
 

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -44,7 +44,7 @@ const generateRandomInteger = maxValue => Math.floor(Math.random() * maxValue);
 class RandomInteger extends React.Component {
   constructor(props) {
     super(props);
-    const { maxValue } = props;
+    const maxValue = props.maxValue;
 
     this.state = {
       number: generateRandomInteger(maxValue),
@@ -129,12 +129,10 @@ class BipolarButton extends React.Component {
   }
 
   render() {
-    const { label } = this.props;
-    const { styling } = this.state;
 
     return (
-      <button className={`btn btn-${styling}`} onClick={this.handleClick}>
-        {label}
+      <button className={`btn btn-${this.state.styling}`} onClick={this.handleClick}>
+        {this.props.label}
       </button>
     );
   }

--- a/sprint_3/3_7_estado_react.md
+++ b/sprint_3/3_7_estado_react.md
@@ -13,6 +13,7 @@
 - [EJERCICIO 4](#ejercicio-4)
 - [EJERCICIO 5](#ejercicio-5)
 - [EJERCICIO 6](#ejercicio-6)
+- [EJERCICIO BONUS 7](#ejercicio-bonus-7)
 
 <!-- /TOC -->
 
@@ -47,7 +48,7 @@ class RandomInteger extends React.Component {
     const maxValue = props.maxValue;
 
     this.state = {
-      number: generateRandomInteger(maxValue),
+      number: generateRandomInteger(maxValue)
     };
   }
 
@@ -65,14 +66,14 @@ Como en este ejemplo el estado nunca cambia más, puede parecer que esto no sirv
 
 Ahora bien, hemos dicho que podemos cambiar el estado. Sin embargo, tenemos que hacerlo de cierta manera. Sabemos que los componentes en React son declarativos: no decimos _cómo_ se hace un componente, sino el _qué_, y React es quien se encarga del _cómo_. A la hora de cambiar los valores del estado, **no podremos asignar directamente los valores a `this.state`** o cualquiera de sus propiedades, sino que utilizaremos el método `setState()` del componente: React se encargará del resto.
 
-Podemos llamar a `setState()` de varias maneras. La más común y sencilla de ellas es pasarle un **objeto literal** con las claves (nombres) de los estados que queremos cambiar y sus valores. Es decir, si tenemos tres estados `a`, `b` y `c`, pero solo queremos cambiar el valor de `c`, pasaremos un objeto `{ c: 'nuevo valor' }`, sin incluir `a` ni `b`. React lo mezclará con el estado actual y solo cambiará las propiedades que deba cambiar.
+Podemos llamar a `setState()` de varias maneras. La más común y sencilla de ellas es pasarle un **objeto literal** con las claves (nombres) del estado que queremos cambiar y sus valores. Es decir, si tenemos tres estados `a`, `b` y `c`, pero solo queremos cambiar el valor de `c`, pasaremos un objeto `{ c: 'nuevo valor' }`, sin incluir `a` ni `b`. React lo mezclará con el estado actual y solo cambiará las propiedades que deba cambiar.
 
 ```js
 class BipolarButton extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      styling: 'info',
+      styling: 'info'
     };
 
     this.handleClick = this.handleClick.bind(this);
@@ -81,7 +82,7 @@ class BipolarButton extends React.Component {
   handleClick() {
     // Nuestra función escuchadora del evento click
     this.setState({
-      styling: 'danger',
+      styling: 'danger'
     });
   }
 
@@ -107,7 +108,7 @@ class BipolarButton extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      styling: 'info',
+      styling: 'info'
     };
 
     this.handleClick = this.handleClick.bind(this);
@@ -123,15 +124,17 @@ class BipolarButton extends React.Component {
       }
 
       return {
-        styling: nextStyling,
+        styling: nextStyling
       };
     });
   }
 
   render() {
-
     return (
-      <button className={`btn btn-${this.state.styling}`} onClick={this.handleClick}>
+      <button
+        className={`btn btn-${this.state.styling}`}
+        onClick={this.handleClick}
+      >
         {this.props.label}
       </button>
     );
@@ -143,7 +146,7 @@ También se puede usar una _arrow function_ más corta y, en este caso, un opera
 
 ```js
 this.setState((prevState, props) => ({
-  styling: prevState.styling === 'info' ? 'danger' : 'info',
+  styling: prevState.styling === 'info' ? 'danger' : 'info'
 })); // este doble paréntesis se suele olvidar de primeras
 ```
 
@@ -208,7 +211,7 @@ Si usásemos un valor de `this.state` después de llamar a `setState()`, podría
 ```js
 this.setState(
   {
-    mensaje: 'nuevo mensaje',
+    mensaje: 'nuevo mensaje'
   },
   () => {
     console.log(this.state.mensaje); // 'nuevo mensaje'
@@ -227,6 +230,118 @@ El `callback` se ejecutará justo después de que el cambio de estado haya tenid
 Sobre el componente cuentaovejas (`SheepCounter`) del ejercicio anterior, añadimos la funcionalidad de que, además de mostrar el número de ovejas, muestra también la imagen de una oveja. Por ejemplo, si el contador está en 6, además de aparecer el número 6 veremos 6 imágenes de ovejas.
 
 > Podéis usar esta imagen por ejemplo: http://www.clker.com/cliparts/e/4/8/7/13280460782141411990Cartoon%20Sheep.svg.hi.png
+
+---
+
+## _Spread operator_
+
+El operador _spread_ (`...`) convierte un array o un objeto en el conjunto de valores que contiene, por lo que nos permite usarlos como si estuvieran escritos en el propio código. Una de las ventajas que nos ofrece el operador _spread_ es que no tenemos por qué saber qué hay en el array u objeto en cada momento.
+
+### _Spreading_ de array
+
+Veamos un par de ejemplos con arrays. Tenemos un array y queremos añadirle un nuevo valor:
+
+```js
+const names = ['Smith', 'White', 'Black', 'Pinkman'];
+
+const newNames = [...names, 'Williams'];
+
+console.log(newNames)); // ['Smith', 'White', 'Black', 'Pinkman', 'Williams']
+```
+
+Ahora pongamos que queremos mezclar dos arrays distintos que tenemos:
+
+```js
+const myBooks = ['1984', 'Brave New World'];
+const myBrotherBooks = ['We', 'Fahrenheit 451'];
+
+const books = [...myBooks, ...myBrotherBooks];
+
+console.log(books); // [`1984`, 'Brave New World', 'We', 'Fahrenheit 451']
+```
+
+### _Spreading_ de objeto
+
+Podemos usar el operador _spread_ también con las propiedades de los objetos. Por ejemplo, para añadir una propiedad nueva o sobreescribirla si ya existe. En este ejemplo copiamos el objeto `person` y lo guardamos en `twinSister`. El objeto `person` sigue existiendo y los dos son independientes:
+
+```js
+const person = {
+  name: 'Marie',
+  lastName: 'Smith',
+  age: 39
+};
+
+const twinSister = { ...person, name: 'Juliette' };
+
+console.log(twinSister); // { name: 'Juliette', lastName: 'Smith', age: 39 }
+```
+
+### Copia vs referencia
+
+Recordemos que en el módulo de javascript aprendimos que si teniamos un array o un objeto literal en una variable, al guardarlo en otra, en realidad guardabamos una _referencia_ del array/objeto.
+
+De manera que si modificábamos o mutábamos una de las dos variables, por ejemplo con un `.push` para el caso del array o cambiando el valor de una propiedad para el caso del objeto, estos cambios también sucedian en la otra variable, ya que el array u objeto contenido en ambas era el mismo.
+
+El operador _spread_ nos permite hacer una copia de un objeto o array en un momento dado. De manera que si cambiamos o mutamos, por ejemplo, el original, la copia no se ve afectada, ya que son independientes y no comparten referencia.
+
+### Actualizando un valor del estado a partir del segundo nivel
+
+Como hemos visto, si tenemos en el estado un objeto con tres claves, por ejemplo:
+
+```js
+this.state = {
+  selectedTab: 4,
+  theme: 'dark',
+  userData: {
+    age: 30,
+    eyeColor: 'soft-caramel',
+    mostHatedFruit: 'banana'
+  }
+};
+```
+
+Podemos actualizarlas con `this.setState()`, pasándole como primer parámetro **un objeto o una funcion que debe devolver un objeto**
+
+```js
+this.setState({ selectedTab: 2 });
+```
+
+o
+
+```js
+this.setState(prevState => {
+  return { selectedTab: 2 };
+});
+```
+
+Este objeto debía tener como mínimo una de las claves que se encuentran en el primer nivel del estado (`selectedTab, theme, userData`) y React se encarga de que las claves no presentes no se vean afectadas.
+
+Pero, y si queremos actualizar una clave que no está a primer nivel, por ejemplo `age`. En estos casos tenemos que identificar la clave madre. En nuestro ejemplo sería `userData` y es la que tenemos que modificar.
+
+Las claves hijas de `userData` (`eyeColor, mostHatedFruit...`) ya no se encuentran a primer nivel y React no las controla, es nuestra responsabilidad que al modificar una las otras no se vean afectadas.
+
+En este punto, si tenéis que modificar la clave `age`, es posible que penseis en algo así:
+
+```js
+this.setState(prevState => {
+  const newUserData = prevState.userData;
+  newUserData.age = 33;
+  return { userData: newUserData };
+});
+```
+
+Pero a React **NO le gusta que mutemos arrays y objetos anidados, mejor si creamos una copia**, operador `spread` al rescate:
+
+```js
+this.setState(prevState => {
+  return {
+    userData: {
+      ...prevState.userData,
+      age: 33
+    }
+  };
+});
+```
 
 ---
 
@@ -250,10 +365,78 @@ Vamos a partir de un objeto con información de un usuario que tenemos en el est
 
 Vamos a crear un formulario donde vamos a poder modificar estos campos del estado.
 
-> NOTA: Cuidado al modificar los campos anidados dentro del objeto `birdthDate`; para modificarlos es muy útil usar en el `setState` el operador spread `...` para mantener el resto de datos de ese objeto. Por ejemplo:
+> NOTA: Cuidado al modificar los campos anidados dentro del objeto `birdthDate`; recuerda que para modificarlos es muy útil usar en el `setState` el operador spread `...` para mantener el resto de datos de ese objeto. Por ejemplo:
 
 ```js
 this.setState((prevState, props) => ({ ...prevState.birthDate, day: 8 }));
+```
+
+### BONUS
+
+#### EJERCICIO BONUS 7
+
+**Fruta fresca**
+
+Vamos a hacer una lista de frutas populares, que nos permita añadir y quitar elementos.
+
+```js
+this.state = {
+  popularFruits: ['kiwi', 'pinneaple', 'strawberry'],
+  newFruit: ''
+};
+```
+
+1. Pintar el listado a partir de la clave del estado `popularFruits`.
+
+2. Pintar un input de texto y un botón con el texto 'Añadir'
+
+3. Cada vez que el input cambie, hay que actualizar la clave del estado `newFruit`
+
+4. Cuando se pulse el botón 'Añadir' hay que:
+
+   - actualizar la clave del estado `popularFruits` con el valor de `newFruit`. Ojo, no vale mutar el array contenido en `popularFruits` con un push. Usaremos `spread` o el método de array `.concat` para generar un nuevo array.
+
+   - actualizar el valor de `newFruit` cn comitas vacias para limpiar el input.
+
+5. Ahora vamos a añadir un botón 'Eliminar' junto a cada fruta, a este botón tenemos que añadirle un atributo `value` o `data-fruit` con el nombre de la fruta junto a la que se encuentra como valor.
+
+6. Cuando se pulse el botón tenemos que recoger la fruta que queremos eliminar y actualizar la clave del estado `popularFruits` con un nuevo array que no contenga dicha fruta. El método `.filter` de array que devuelve una copia nueva puede ayudaros con esta tarea.
+
+Al turrón!
+
+---
+
+### Spread y parámetros de funciones
+
+El operador _spread_ también nos puede ser útil para pasar todos los valores de un array como parámetros a una función:
+
+```js
+const vowels = ['a', 'e', 'i', 'o', 'u'];
+
+console.log(...vowels);
+```
+
+Esto sería equivalente a:
+
+```js
+//
+console.log(vowels[0], vowels[1], vowels[2], vowels[3], vowels[4]);
+```
+
+### _Rest parameters_
+
+Cuando declaramos una función propia también nos sirve para almacenar los parámetros sobrantes (_rest parameters_) en una sola variable:
+
+```js
+function showFavoriteFruits(first, ...rest) {
+  const restOfFruits = rest.join(' and ');
+  console.log(
+    `My favourite fruit is the ${first}, although I like ${restOfFruits} also.`
+  );
+}
+
+const myFavoriteFruits = ['orange', 'banana', 'pear'];
+showFavoriteFruits(...myFavoriteFruits); // 'My favourite fruit is the orange, although I like banana and pear also.'
 ```
 
 ---

--- a/sprint_3/3_9_buenas_practicas.md
+++ b/sprint_3/3_9_buenas_practicas.md
@@ -7,6 +7,10 @@
 - [EJERCICIO 1](#ejercicio-1)
 - [EJERCICIO 2](#ejercicio-2)
 - [EJERCICIO 3](#ejercicio-3)
+- [EJERCICIO 4](#ejercicio-4)
+- [EJERCICIO 5](#ejercicio-5)
+- [EJERCICIO 6](#ejercicio-6)
+- [EJERCICIO 7](#ejercicio-7)
 
 <!-- /TOC -->
 
@@ -150,9 +154,269 @@ a) Para terminar, vamos a repasar los ejercicios anteriores y comprobar que no t
 
 b) En el ejercicio anterior vamos a extraer un nuevo componente llamado `ColapsiblePalette`. ¿Dónde hay que poner el `key` ahora?
 
+## Destructuring
+
+La sintaxis _destructuring_ de ES6 nos facilita recoger valores de una estructura de datos, como los arrays o los objetos. Simulando la sintaxis de un array o de un objeto, en cada caso, podemos declarar varias variables a la vez, ¡y en una sola línea! Vemos unos ejemplos a continuación:
+
+### _Destructuring_ de arrays
+
+Vamos a ver un par de ejemplos con arrays. Tenemos un array de tres valores, y queremos coger los dos primeros en las variables `x` e `y`:
+
+```js
+const coordinates = [150, 35, 12]; // x = 150, y = 35, z = 12
+
+// hasta ahora lo habríamos hecho así
+const x = coordinates[0];
+const y = coordinates[1];
+console.log(`The point is at (${x}, ${y})`); // The point is at (150, 35)
+
+// usando destructuring de array
+const [x, y] = coordinates;
+console.log(`The point is at (${x}, ${y})`); // The point is at (150, 35)
+```
+
+Como vemos, es más sencillo de escribir que manejar los índices. Ahora supongamos que del array solo nos interesa la tercera coordenada, la que sería la coordenada `z`, pero no nos interesan los valores de antes. Sencillo: dejamos las posiciones vacías y le damos nombre solo a la tercera posición:
+
+```js
+const coordinates = [150, 35, 12];
+
+// hasta ahora lo habríamos hecho así
+const z = coordinates[2];
+console.log(`The z-index is ${z}`); // The z-index is 12
+
+// usando destructuring de array
+const [, , z] = coordinates;
+console.log(`The z-index is ${z}`); // The z-index is 12
+```
+
+---
+
+#### EJERCICIO 4
+
+**La carrera de escobas**
+
+Partiendo de este array con los resultados de una carrera de escobas ya ordenados, vamos a sacar del array e imprimir en la consola el podium, es decir, los nombres y tiempos del primero, segundo y tercer clasificado usando destructuring del array.
+
+```js
+const users = [
+  { name: 'Nymphadora Tonks', time: 9 },
+  { name: 'Cedric Diggory', time: 28 },
+  { name: 'Cho Chang', time: 35 },
+  { name: 'Luna Lovegood', time: 45 },
+  { name: 'Gregory Goyle', time: 56 }
+];
+```
+
+---
+
+### _Destructuring_ de objetos
+
+Vamos ahora con los objetos. En los objetos, los valores no se identifican por su posición, sino que las propiedades tienen su propio nombre, así que tendremos que tener en cuenta esto al asignar los valores con _destructuring_.
+
+Queremos coger el valor de una propiedad de un objeto y guardarla en una variable con el mismo nombre:
+
+```js
+const person = {
+  name: 'Marie',
+  lastName: 'Smith',
+  age: 39,
+  languages: ['English', 'French']
+};
+
+const { name } = person;
+console.log(`Hello ${name}`); // Hello Marie
+```
+
+> Este caso es típico: si guardamos el nombre como `name` en este contexto (`window`), estaríamos sobrescribiendo `window.name`, que es una propiedad existente del objeto `window` en los navegadores.
+
+Como no queremos sobreescrituras ¿Y si quisiéramos cambiarle el nombre a la variable porque el nombre de la propiedad no es apropiado?
+
+```js
+const { name: personName } = person;
+console.log(`Hello ${personName}`); // Hello Marie
+```
+
+Ahora un _destructuring_ dentro de otro. Si queremos el segundo valor del array que está en una propiedad, el segundo idioma de Marie, haríamos:
+
+```js
+const person = {
+  name: 'Marie',
+  lastName: 'Smith',
+  age: 39,
+  languages: ['English', 'French']
+};
+
+const { languages } = person;
+const [, secondLanguage] = languages;
+console.log(`${secondLanguage} is my second language`); // French is my second language
+```
+
+Pero también podemos hacerlo todo en uno sin pasar por el paso intermedio de definir `languages` primero, aunque pueda parecer un lío:
+
+```js
+const {
+  languages: [, secondLanguage]
+} = person;
+console.log(`${secondLanguage} is my second language`); // French is my second language
+```
+
+---
+
+#### EJERCICIO 5
+
+**De nuevo la carrera de escobas**
+
+Revisa el ejercicio 1 para acceder al nombre y tiempo de los ganadores usando destructuring de array y de objeto para imprimirlos en la consola.
+
+```js
+const users = [
+  { name: 'Nymphadora Tonks', time: 9 },
+  { name: 'Cedric Diggory', time: 28 },
+  { name: 'Cho Chang', time: 35 },
+  { name: 'Luna Lovegood', time: 45 },
+  { name: 'Gregory Goyle', time: 56 }
+];
+```
+
+### _Destructuring_ en React
+
+Llegados a este punto, es posible que te estés preguntando,muchas "Por mis props ¿dónde encaja en React?"
+Párate a pensar en un componente de clase, cuantas veces escribes `this.props.something` o en uno funcional `props.something`, ¡seguro que bastantes!
+
+Veamos un ejemplo, con un componente llamado `Field` que pinta un `label` y un `input` cada vez que es instanciado.
+
+```js
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class Field extends Component {
+  render() {
+    return (
+      <div className={`Field ${this.props.name || ''}`}>
+        <label htmlFor={this.props.id}>{this.props.label}</label>
+        <input
+          id={this.props.id}
+          name={this.props.name || this.props.id}
+          type={this.props.type}
+          onChange={this.props.onChange}
+          value={this.props.value}
+        />
+      </div>
+    );
+  }
+}
+
+Field.defaultTypes = {
+  type: 'text'
+};
+
+Field.propTypes = {
+  className: Proptypes.string,
+  id: Proptypes.string.isRequired,
+  label: Proptypes.string.isRequired,
+  name: Proptypes.string,
+  type: Proptypes.string,
+  onChange: Proptypes.string.isRequired,
+  value: Proptypes.string.isRequired,
+  placeholder: Proptypes.string.isRequired
+};
+
+export default Field;
+```
+
+Si queremos que el `html` devuelto (`return`) en el `render` quede más limpito podemos hacer algo así:
+
+```js
+...
+
+class Field extends Component {
+  render() {
+    const className = this.props.className;
+    const id = this.props.id;
+    const label = this.props.label;
+    const name = this.props.name;
+    const type = this.props.type;
+    const onChange = this.props.onChange;
+    const value = this.props.value;
+    const placeholder = this.props.placeholder;
+
+    return (
+      <div className={`Field ${className || ''}`}>
+        <label htmlFor={id}>{label}</label>
+        <input
+          id={id}
+          name={name || id}
+          type={type}
+          placeholder={placeholder}
+          onChange={onChange}
+          value={value}
+        />
+      </div>
+    );
+  }
+}
+
+...
+```
+
+Este código es un poco más legible, pero a costa de escribir más lineas.
+
+Si te fijas bien hemos creado una constante por cada propiedad del objeto `this.props`. A esta constante la hemos llamado igual que a la propiedad que contiene el valor que queremos guardar en ella.
+
+Con _destructuring_ podemos hacer esto mismo escribiendo menos código:
+
+```js
+...
+
+class Field extends Component {
+  render() {
+    const {
+      className,
+      id,
+      label,
+      name,
+      type,
+      onChange,
+      value,
+      placeholder
+    } = this.props;
+
+    return (
+      <div className={`Field ${className || ''}`}>
+        <label htmlFor={id}>{label}</label>
+        <input
+          id={id}
+          name={name || id}
+          type={type}
+          placeholder={placeholder}
+          onChange={onChange}
+          value={value}
+        />
+      </div>
+    );
+  }
+}
+...
+```
+
+#### EJERCICIO 6
+
+**Destructurando props y estado**
+
+Vamos a partir del ejercicio **Formulario para pelis** de la sesión **Estado en React 2** y a hacer destructuring de los objetos `this.props` y `this.state`.
+
+#### EJERCICIO 7
+
+**Destructuring everywhere**
+
+En el ejercicio anterior ¿localizas algún otro objeto dónde hacer destructuring?
+
+**PISTA**: observa tu handler, quizás estés creando una constante y asignandole el valor contenido en la propiedad `value` del objeto `event.currentTarget`.
+
 ---
 
 ## Recursos externos
 
 - [Conditional Rendering](https://reactjs.org/docs/conditional-rendering.html)
 - [Lists and keys](https://reactjs.org/docs/lists-and-keys.html)
+- [Destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)

--- a/sprint_3/3_9_buenas_practicas.md
+++ b/sprint_3/3_9_buenas_practicas.md
@@ -280,10 +280,10 @@ const users = [
 
 ### _Destructuring_ en React
 
-Llegados a este punto, es posible que te estés preguntando,muchas "Por mis props ¿dónde encaja en React?"
-Párate a pensar en un componente de clase, cuantas veces escribes `this.props.something` o en uno funcional `props.something`, ¡seguro que bastantes!
+Llegado este punto, es posible que te estés preguntando, "Por mis props ¿dónde encaja esto en React?"
+Piensa en los componentes que has desarrollado hasta ahora, ¿cuantas veces has escrito `this.props.something` (clase) o `props.something` (funcional)?, ¡seguro que bastantes!
 
-Veamos un ejemplo, con un componente llamado `Field` que pinta un `label` y un `input` cada vez que es instanciado.
+Veamos un ejemplo de la definición de un componente llamado `Field` que pinta un `label` y un `input` cada vez que es instanciado.
 
 ```js
 import React, { Component } from 'react';
@@ -361,7 +361,7 @@ class Field extends Component {
 
 Este código es un poco más legible, pero a costa de escribir más lineas.
 
-Si te fijas bien hemos creado una constante por cada propiedad del objeto `this.props`. A esta constante la hemos llamado igual que a la propiedad que contiene el valor que queremos guardar en ella.
+Si te fijas bien, hemos creado una constante por cada propiedad del objeto `this.props`. A esta constante la hemos llamado igual que a la propiedad que contiene el valor que queremos guardar en ella.
 
 Con _destructuring_ podemos hacer esto mismo escribiendo menos código:
 
@@ -398,6 +398,8 @@ class Field extends Component {
 }
 ...
 ```
+
+Voila!
 
 #### EJERCICIO 6
 

--- a/sprint_3/3_9_buenas_practicas.md
+++ b/sprint_3/3_9_buenas_practicas.md
@@ -266,7 +266,7 @@ console.log(`${secondLanguage} is my second language`); // French is my second l
 
 **De nuevo la carrera de escobas**
 
-Revisa el ejercicio 1 para acceder al nombre y tiempo de los ganadores usando destructuring de array y de objeto para imprimirlos en la consola.
+Revisa el ejercicio 4 para acceder al nombre y tiempo de los ganadores usando destructuring de array y de objeto para imprimirlos en la consola.
 
 ```js
 const users = [


### PR DESCRIPTION
- [x]  spread se introduce en la 3.7 para modificar estado a 2 nivel
Esta parte es la que me ha generado más dudas:
    - Añade la explicación existente de spread
    - Amplia la explicación enfocada a setState (igual aquí me he enrollado un pelín o repetido)
    - Quita los ejercicios existentes. (Eran de JS vainilla y no quería perder el foco de setState)
    - Añade un ejercicio de BONUS más complejo y guiado para ver spread con arrays.
    - Añade spread + rest params a la zona de BONUS (aunque casi la quito me acordé de una alumna de la mañana que lo aplicó super bien)
- [x]  destructuring se introduce en la 3.9 junto a buenas prácticas
    - Añade la explicación existente
    - Añade los ejercicios existentes con JS, ya que en esta no había muchos y es una lección relajada.
    - Añade un punto más a la explicación 'Destructuring en React', para contextualizar y con ejemplos progresivos.
    - Añade un par de ejercicios de destructuring en React.
- [x]  revisar 3.1-3.8 para quitar destructuring de ejemplos